### PR TITLE
Merge pull request #2 from ptim/fix-postcss-tailwind-config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: [
     require("postcss-import"),
-    require("tailwindcss")("./tailwind.config.js"),
+    require("tailwindcss"),
     require("postcss-preset-env")({
       autoprefixer: { grid: true },
       features: {


### PR DESCRIPTION
Namely: 

> There was an error trying to load the config "tailwind" for the macro imported from "tailwind.macro. Please see the error thrown for more information.